### PR TITLE
Wagtail 7.0 Maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - uses: pre-commit/action@v3.0.1
 
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+- Add testing for Wagtail 6.3 & 7.0
+- Use python 3.13 across workflows and formatting
+
 ## v2.0.1 (2024-10-22)
 
 - Add tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,12 @@ Home = "https://github.com/torchbox/django-birdbath"
 
 [project.optional-dependencies]
 dev = [
-    "django~=4.2",
+    "django>=4.2",
     "pre-commit>=3.8.0",
     "pytest~=8.3",
     "pytest-django~=4.9",
     "ruff==0.6.9",
-    "wagtail~=5.2",
+    "wagtail>=5.2",
 ]
 
 [tool.flit.module]
@@ -44,7 +44,7 @@ name = "birdbath"
 include = ["LICENSE", "CHANGELOG.md", "README.md"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py313"
 
 exclude = [
     ".github",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
   # Django versions with their respectively supported Python versions and the most recent Wagtail LTS
-  py{39,310,311,312,313}-django42-wagtail62
-  py{310,311,312,313}-django{50,51}-wagtail62
+  py{39,310,311,312}-django42-wagtail70
+  py{310,311,312,313}-django{51,52}-wagtail70
   # Old Wagtail versions with the oldest Django LTS and Python
   py39-django42-wagtail52
 isolated_build = True
@@ -18,10 +18,10 @@ python =
 [testenv]
 deps =
     django42: Django>=4.2,<5.0
-    django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
     wagtail52: wagtail>=5.2,<5.3
-    wagtail62: wagtail>=6.2,<6.3
+    wagtail70: wagtail>=7.0,<7.1
     pytest
     pytest-django
 extras = dev

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
   # Django versions with their respectively supported Python versions and the most recent Wagtail LTS
-  py{39,310,311,312}-django42-wagtail70
-  py{310,311,312,313}-django{51,52}-wagtail70
+  py{39,310,311,312}-django42-wagtail{63,70}
+  py{310,311,312,313}-django{51,52}-wagtail{63,70}
   # Old Wagtail versions with the oldest Django LTS and Python
   py39-django42-wagtail52
 isolated_build = True


### PR DESCRIPTION
This pull request updates the `tox.ini` configuration to align with the latest supported versions of Django and Wagtail.

### Updates to version compatibility:

* Updated the `envlist` in `tox.ini` to include Wagtail 6.3 & Wagtail 7.0 and adjust the associated Django version ranges accordingly.
* Updated dependency version ranges in the `[testenv]` section to include Django 5.2 and Wagtail 7.0 while removing references to Django 5.0 and Wagtail 6.2.