### PR TITLE
Wagtail 7.2 Maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.6.9'
+    rev: 'v0.14.6'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add testing/support for Wagtail 7.2
 - Add testing for Wagtail 6.3, 7.0 and 7.1
 - Use python 3.13 across workflows and formatting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Add testing/support for Wagtail 7.2
+- Drop testing/support for Python 3.9
+- Add testing/support for Python 3.14
 - Pin the minimum supported Wagtail version to 7.0
 
 ## v2.0.1 (2024-10-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add testing for Wagtail 6.3 & 7.0
+- Add testing for Wagtail 6.3, 7.0 and 7.1
 - Use python 3.13 across workflows and formatting
 
 ## v2.0.1 (2024-10-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## Unreleased
 
 - Add testing/support for Wagtail 7.2
-- Add testing for Wagtail 6.3, 7.0 and 7.1
-- Use python 3.13 across workflows and formatting
+- Pin the minimum supported Wagtail version to 7.0
 
 ## v2.0.1 (2024-10-22)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,10 @@ Home = "https://github.com/torchbox/django-birdbath"
 [project.optional-dependencies]
 dev = [
     "django>=4.2",
-    "pre-commit>=3.8.0",
-    "pytest~=8.3",
-    "pytest-django~=4.9",
-    "ruff==0.6.9",
+    "pre-commit>=4.3.0",
+    "pytest~=8.4",
+    "pytest-django~=4.11",
+    "ruff==0.4.10",
     "wagtail>=7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,18 +11,18 @@ license = {file = "LICENSE"}
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 keywords = ["django", "anonymization", "data cleaning"]
 dependencies = [
     "Faker>=8",
     "Django>=4.2",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.urls]
 Home = "https://github.com/torchbox/django-birdbath"
@@ -34,7 +34,7 @@ dev = [
     "pytest~=8.3",
     "pytest-django~=4.9",
     "ruff==0.6.9",
-    "wagtail>=5.2",
+    "wagtail>=7.0",
 ]
 
 [tool.flit.module]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "pre-commit>=4.3.0",
     "pytest~=8.4",
     "pytest-django~=4.11",
-    "ruff==0.4.10",
+    "ruff==0.14.6",
     "wagtail>=7.0",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,10 +27,6 @@ commands =
     pytest {posargs}
 
 [testenv:lint]
-deps =
-    black==23.1.0
-    flake8==6.0.0
-    isort==5.12.0
 commands =
     ruff check .
     ruff format . --check

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,25 @@
 [tox]
 envlist =
-  # Django versions with their respectively supported Python versions and the most recent Wagtail LTS
-  py{39,310,311,312}-django42-wagtail{63,70,71}
-  py{310,311,312,313}-django{51,52}-wagtail{63,70,71}
-  # Old Wagtail versions with the oldest Django LTS and Python
-  py39-django42-wagtail52
+  py{310,311,312}-django42-wagtail{70,72}
+  py{310,311,312,313}-django{51,52}-wagtail{70,72}
+
 isolated_build = True
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [testenv]
 deps =
     django42: Django>=4.2,<5.0
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
-    wagtail52: wagtail>=5.2,<5.3
     wagtail70: wagtail>=7.0,<7.1
-    wagtail71: wagtail>=7.1,<7.2
+    wagtail72: wagtail>=7.2,<7.3
     pytest
     pytest-django
 extras = dev

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
   # Django versions with their respectively supported Python versions and the most recent Wagtail LTS
-  py{39,310,311,312}-django42-wagtail{63,70}
-  py{310,311,312,313}-django{51,52}-wagtail{63,70}
+  py{39,310,311,312}-django42-wagtail70
+  py{310,311,312,313}-django{51,52}-wagtail70
   # Old Wagtail versions with the oldest Django LTS and Python
   py39-django42-wagtail52
 isolated_build = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
   # Django versions with their respectively supported Python versions and the most recent Wagtail LTS
-  py{39,310,311,312}-django42-wagtail70
-  py{310,311,312,313}-django{51,52}-wagtail70
+  py{39,310,311,312}-django42-wagtail{63,70}
+  py{310,311,312,313}-django{51,52}-wagtail{63,70}
   # Old Wagtail versions with the oldest Django LTS and Python
   py39-django42-wagtail52
 isolated_build = True

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
   py{310,311,312}-django42-wagtail{70,72}
   py{310,311,312,313}-django{51,52}-wagtail{70,72}
+  py314-django52-wagtail{70,72}
 
 isolated_build = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
   # Django versions with their respectively supported Python versions and the most recent Wagtail LTS
-  py{39,310,311,312}-django42-wagtail{63,70}
-  py{310,311,312,313}-django{51,52}-wagtail{63,70}
+  py{39,310,311,312}-django42-wagtail{63,70,71}
+  py{310,311,312,313}-django{51,52}-wagtail{63,70,71}
   # Old Wagtail versions with the oldest Django LTS and Python
   py39-django42-wagtail52
 isolated_build = True
@@ -22,6 +22,7 @@ deps =
     django52: Django>=5.2,<5.3
     wagtail52: wagtail>=5.2,<5.3
     wagtail70: wagtail>=7.0,<7.1
+    wagtail71: wagtail>=7.1,<7.2
     pytest
     pytest-django
 extras = dev

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-  py{310,311,312}-django42-wagtail{70,72}
-  py{310,311,312,313}-django{51,52}-wagtail{70,72}
-  py314-django52-wagtail{70,72}
+  py{310,311,312}-django42-wagtail{63,70,72}
+  py{310,311,312,313}-django{51,52}-wagtail{63,70,72}
+  py314-django52-wagtail72
 
 isolated_build = True
 
@@ -19,6 +19,7 @@ deps =
     django42: Django>=4.2,<4.3
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
+    wagtail63: wagtail>=6.3,<6.4
     wagtail70: wagtail>=7.0,<7.1
     wagtail72: wagtail>=7.2,<7.3
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ python =
 
 [testenv]
 deps =
-    django42: Django>=4.2,<5.0
+    django42: Django>=4.2,<4.3
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
     wagtail70: wagtail>=7.0,<7.1


### PR DESCRIPTION
This pull request updates the project's Python and Wagtail version support, removes support for Python 3.9, and updates development dependencies. 

**Python version support:**
- Dropped support for Python 3.9 and added support for Python 3.14 throughout the project

**Wagtail version support:**
- Added testing and support for Wagtail 7.2, and updated test configurations to use Wagtail 7.0 and 7.2. Removed references to older Wagtail versions.

**Dependency updates:**
- Updated development dependencies in `pyproject.toml` to newer versions of `pre-commit`, `pytest`, `pytest-django`, and `ruff`, and increased the minimum required Wagtail version for development to 7.0.

**Project metadata:**
- Updated the Python version classifiers and the minimum required Python version in `pyproject.toml` to reflect the new supported versions.

**Changelog:**
- Updated `CHANGELOG.md` to document the new Python and Wagtail version support.

