### PR TITLE
Wagtail 7.4 Maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
-- Add testing/support for Wagtail 7.2
+- Add testing/support for Wagtail 7.4 LTS
+- Add testing/support for Wagtail 7.3
+- Drop testing/support for Wagtail 7.1 and 7.2 (end of life upstream)
 - Drop testing/support for Python 3.9
 - Add testing/support for Python 3.14
 - Pin the minimum supported Wagtail version to 7.0
-- Drop Wagtail 5.x and 6.x from the test matrix; now covering Wagtail 7.0 and 7.2
+- Drop Wagtail 5.x and 6.x from the test matrix; now covering Wagtail 7.0, 7.3, and 7.4
 - Add Django 6.0 and Python 3.14 to the test matrix
+- Fix invalid `Django 5.1 + Wagtail 7.3` combination in the test matrix (Wagtail 7.3 does not support Django 5.1)
 - Remove deprecated `default_app_config` from `birdbath/__init__.py`
 
 ## v2.0.1 (2024-10-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Drop testing/support for Python 3.9
 - Add testing/support for Python 3.14
 - Pin the minimum supported Wagtail version to 7.0
+- Drop Wagtail 5.x and 6.x from the test matrix; now covering Wagtail 7.0 and 7.2
+- Add Django 6.0 and Python 3.14 to the test matrix
+- Remove deprecated `default_app_config` from `birdbath/__init__.py`
 
 ## v2.0.1 (2024-10-22)
 

--- a/birdbath/__init__.py
+++ b/birdbath/__init__.py
@@ -4,5 +4,3 @@ don't need in your development environment, or whatever it is you need to do.
 """
 
 __version__ = "2.0.1"
-
-default_app_config = "birdbath.apps.BirdBathConfig"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ name = "birdbath"
 include = ["LICENSE", "CHANGELOG.md", "README.md"]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py39"
 
 exclude = [
     ".github",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ name = "birdbath"
 include = ["LICENSE", "CHANGELOG.md", "README.md"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 exclude = [
     ".github",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -19,3 +19,5 @@ INSTALLED_APPS = [
 SECRET_KEY = "not-so-secret-for-tests"
 
 STATIC_URL = "/static/"
+
+USE_TZ = True

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
   py{310,311,312}-django42-wagtail70
   py{310,311,312}-django42-wagtail72
   py{310,311,312,313}-django{51,52}-wagtail{70,72}
-  py{312,313,314}-django60-wagtail{70,72}
+  py{312,313,314}-django60-wagtail72
 isolated_build = True
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-  py{39,310,311,312}-django42-wagtail{70,72}
+  py{39,310,311,312}-django42-wagtail70
+  py{310,311,312}-django42-wagtail72
   py{310,311,312,313}-django{51,52}-wagtail{70,72}
   py{312,313,314}-django60-wagtail{70,72}
 isolated_build = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
-  py{310,311,312}-django42-wagtail70
-  py{310,311,312}-django42-wagtail72
-  py{310,311,312,313}-django{51,52}-wagtail{70,72,73}
-  py{312,313,314}-django60-wagtail{72,73}
+  py{310,311,312}-django42-wagtail{70,73}
+  py{310,311,312,313}-django51-wagtail70
+  py{310,311,312,313}-django52-wagtail70
+  py{310,311,312,313,314}-django52-wagtail{73,74}
+  py{312,313,314}-django60-wagtail{73,74}
 isolated_build = True
 
 [gh-actions]
@@ -21,8 +22,8 @@ deps =
     django52: Django>=5.2,<5.3
     django60: Django>=6.0,<6.1
     wagtail70: wagtail>=7.0,<7.1
-    wagtail72: wagtail>=7.2,<7.3
     wagtail73: wagtail>=7.3,<7.4
+    wagtail74: wagtail>=7.4,<7.5
     pytest
     pytest-django
 extras = dev

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,8 @@ commands =
     pytest {posargs}
 
 [testenv:lint]
+deps =
+    ruff==0.14.6
 commands =
     ruff check .
     ruff format . --check

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{39,310,311,312}-django42-wagtail70
+  py{310,311,312}-django42-wagtail70
   py{310,311,312}-django42-wagtail72
   py{310,311,312,313}-django{51,52}-wagtail{70,72}
   py{312,313,314}-django60-wagtail{70,72}

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
   py{310,311,312}-django42-wagtail70
   py{310,311,312}-django42-wagtail72
-  py{310,311,312,313}-django{51,52}-wagtail{70,72}
-  py{312,313,314}-django60-wagtail72
+  py{310,311,312,313}-django{51,52}-wagtail{70,72,73}
+  py{312,313,314}-django60-wagtail{72,73}
 isolated_build = True
 
 [gh-actions]
@@ -22,6 +22,7 @@ deps =
     django60: Django>=6.0,<6.1
     wagtail70: wagtail>=7.0,<7.1
     wagtail72: wagtail>=7.2,<7.3
+    wagtail73: wagtail>=7.3,<7.4
     pytest
     pytest-django
 extras = dev

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist =
-  py{310,311,312}-django42-wagtail{63,70,72}
-  py{310,311,312,313}-django{51,52}-wagtail{63,70,72}
-  py314-django52-wagtail72
-
+  py{39,310,311,312}-django42-wagtail{70,72}
+  py{310,311,312,313}-django{51,52}-wagtail{70,72}
+  py{312,313,314}-django60-wagtail{70,72}
 isolated_build = True
 
 [gh-actions]
@@ -19,7 +18,7 @@ deps =
     django42: Django>=4.2,<4.3
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
-    wagtail63: wagtail>=6.3,<6.4
+    django60: Django>=6.0,<6.1
     wagtail70: wagtail>=7.0,<7.1
     wagtail72: wagtail>=7.2,<7.3
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
   py{310,311,312}-django42-wagtail{70,73}
-  py{310,311,312,313}-django51-wagtail70
-  py{310,311,312,313}-django52-wagtail70
+  py{310,311,312,313}-django{51,52}-wagtail70
   py{310,311,312,313,314}-django52-wagtail{73,74}
   py{312,313,314}-django60-wagtail{73,74}
 isolated_build = True


### PR DESCRIPTION
# Wagtail 7.4 LTS maintenance

## Summary

- Add Wagtail 7.4 LTS to the test matrix
- Drop Wagtail 7.1 and 7.2 (both end-of-life upstream as of 2026-02-02 and 2026-05-04)
- Keep coverage of Wagtail 7.0 LTS and 7.3 (still in security support)
- Add the missing `django42 + wagtail73` combination, and remove the invalid `django51 + wagtail73` combinations the previous envlist produced (Wagtail 7.3 supports Django 4.2/5.2/6.0, not 5.1)
- Drop Python 3.9 support; minimum is now Python 3.10
- Restrict Django 6.0 envs to Wagtail 7.3+ (Wagtail 7.0 predates Django 6.0)
- Fix developer tooling consistency: replace stale `black`/`flake8`/`isort` deps in `[testenv:lint]` with `ruff==0.14.6`, align ruff version across `pyproject.toml` and `.pre-commit-config.yaml`
- Fix `ruff.target-version` from `py313` to `py310` (should reflect minimum supported Python, not developer Python)
- Set `USE_TZ = True` in test settings to match Django 5.0+ default and silence `RemovedInDjango50Warning` on 4.2 runs
- Remove deprecated `default_app_config` from `birdbath/__init__.py`

## Resulting test matrix (30 envs)

Combinations match the official [Wagtail / Django / Python compatibility table](https://docs.wagtail.org/en/stable/releases/upgrading.html#compatible-django-python-versions):

- Wagtail 7.0 LTS: Django 4.2/5.1/5.2 with Python 3.10–3.13
- Wagtail 7.3: Django 4.2/5.2/6.0 with Python 3.10–3.14
- Wagtail 7.4 LTS: Django 5.2/6.0 with Python 3.10–3.14

## Test plan

- [ ] Full CI matrix green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)